### PR TITLE
fix(macOS): fix startup error about SQLite

### DIFF
--- a/src/background/db.ts
+++ b/src/background/db.ts
@@ -1,6 +1,13 @@
 import sqlite3 from 'sqlite3'
+import path from 'path'
 
-const db = new sqlite3.Database('data.db')
+let dbFile = path.join(process.cwd(), 'data.db')
+if (process.platform === 'darwin' && __dirname.includes('/app.asar')) {
+	dbFile = path.join(__dirname, '/data.db').replace('/app.asar', '')
+}
+console.log('Database location:', dbFile)
+
+const db = new sqlite3.Database(dbFile)
 
 db.serialize(() => {
 	db.run(`


### PR DESCRIPTION
Closes #38

The root problem is that, on macOS, `process.cwd()` is the current user's home directory (which [`sqlite3`](https://www.npmjs.com/package/sqlite3) apparently does not have write access to in our application) and our SQLite database location was in `process.cwd()`. This PR detects when the application is running as a packaged, installed bundle on macOS and changes the database path to be within the application directory, where it has permission to write files. Unfortunately, this fix only works when Rundown Editor is installed to the actual Applications directory. This means that the `.app` within the macOS `.zip` build is seemingly unfixable, so [it has been disabled for now](https://github.com/SuperFlyTV/sofie-automation-rundown-editor/commit/070a7c7732c624f96dcfb32dd34f763ed65370bb) and we'll only provide `.dmg` builds for macOS from now on.

Mysteriously, [`server-core-integration`](https://github.com/nrkno/tv-automation-server-core/blob/c943574aafab19d23fa4bc441d37b88015640624/packages/server-core-integration/src/lib/coreConnection.ts#L89-L99) is able to use the npm package [`data-store`](https://www.npmjs.com/package/data-store) to write `sofie-rundown-editor.json` to the home directory. Perhaps SQLite fails because it is a native extension? Maybe it is using some different filesystem API. Regardless, this PR fixes the error and the application seems to run okay despite this disparity between `sqlite3` and `data-store`.

EDIT: This PR was informed by https://github.com/electron-userland/electron-builder/issues/1474.