### PR TITLE
Fix not being able to set values to 0

### DIFF
--- a/src/util/lib.ts
+++ b/src/util/lib.ts
@@ -28,7 +28,7 @@ export const editField = <T extends any>(
 		},
 		set(value: T) {
 			const self = this as any
-			const isValue = value != '' && value !== undefined && value !== null
+			const isValue = value !== '' && value !== undefined && value !== null
 
 			if (!self.editObject) {
 				self.editObject = {


### PR DESCRIPTION
Setting the value of numeric piece fields to `0` causes their value to be set to `undefined` instead. For example it is impossible to set the start time of a piece to `0`