### PR TITLE
fix: show empty values in the start and duration field on pieces

### DIFF
--- a/frontend/src/components/rundown/piecePropertiesForm.tsx
+++ b/frontend/src/components/rundown/piecePropertiesForm.tsx
@@ -48,7 +48,9 @@ export function PiecePropertiesForm({ piece }: { piece: Piece }) {
 				}}
 			>
 				<Form.Group className="mb-3">
-					<Form.Text>Piece type: {piece.pieceType}</Form.Text>
+					<Form.Text>
+						Piece type: {piece.pieceType} {!piece.start && piece.start !== 0 ? '(AdLib)' : ''}
+					</Form.Text>
 				</Form.Group>
 
 				<form.Field
@@ -79,9 +81,12 @@ export function PiecePropertiesForm({ piece }: { piece: Piece }) {
 								<Form.Control
 									name={field.name}
 									type="number"
-									value={Number(field.state.value ?? 0)}
+									value={field.state.value ?? ''}
 									onBlur={field.handleBlur}
-									onChange={(e) => field.handleChange(Number(e.target.value))}
+									onChange={(e) => {
+										const val = e.target.value
+										field.handleChange(val === '' ? undefined : Number(val))
+									}}
 								/>
 							</Form.Group>
 							<FieldInfo field={field} />
@@ -97,9 +102,12 @@ export function PiecePropertiesForm({ piece }: { piece: Piece }) {
 								<Form.Control
 									name={field.name}
 									type="number"
-									value={Number(field.state.value ?? 0)}
+									value={field.state.value ?? ''}
 									onBlur={field.handleBlur}
-									onChange={(e) => field.handleChange(Number(e.target.value))}
+									onChange={(e) => {
+										const val = e.target.value
+										field.handleChange(val === '' ? undefined : Number(val))
+									}}
 								/>
 							</Form.Group>
 							<FieldInfo field={field} />


### PR DESCRIPTION
Show empty values in the start and duration field on pieces correctly to the user.

On piece creation the start and duration fields were not initialized, thus the rundown editor treated the created pieces as AdLibs. I've changed, so now the start and duration fields stay empty, and it's signaled to the user that it's an AdLib piece.

### Before:
<img width="701" height="503" alt="image" src="https://github.com/user-attachments/assets/54150a15-9f3b-478d-9823-d0594d769b59" />

### After:
<img width="706" height="498" alt="image" src="https://github.com/user-attachments/assets/eb5aeaf3-17bb-44d7-8fe1-dcb4725a5493" />
